### PR TITLE
Changed encoding to utf-8 from unicode to save characters to file.

### DIFF
--- a/rosetta_sip_factory/sip_builder.py
+++ b/rosetta_sip_factory/sip_builder.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import errno
 
 from lxml import etree as ET
 

--- a/rosetta_sip_factory/sip_builder.py
+++ b/rosetta_sip_factory/sip_builder.py
@@ -26,8 +26,9 @@ mets_dnx_nsmap = {
     'dnx': 'http://www.exlibrisgroup.com/dps/dnx'
 }
 
+set_encoding = 'utf-8'
 
-def _build_dc_sip(output_dir, sip_title, encoding='unicode'):
+def _build_dc_sip(output_dir, sip_title, encoding=set_encoding):
     dc_xml = ET.Element('{%s}record' % DC_NS, nsmap=dc_nsmap)
     title = ET.SubElement(dc_xml, '{%s}title' % DC_NS, nsmap=dc_nsmap)
     title.text = sip_title
@@ -80,7 +81,7 @@ def build_sip(
         mets_filename=None,
         sip_title=None,
         output_dir=None,
-        encoding="unicode",
+        encoding=set_encoding,
         structmap_type="DEFAULT"):
     """Builds Submission Information Package.
 
@@ -256,7 +257,7 @@ def build_single_file_sip(ie_dmd_dict=None,
                           sip_title=None,
                           output_dir=None,
                           mets_filename=None,
-                          encoding='unicode'):
+                          encoding=set_encoding):
     # build mets
     mets = build_single_file_mets(
         ie_dmd_dict=ie_dmd_dict,
@@ -327,7 +328,7 @@ def build_sip_from_json(
     sip_title=None,
     output_dir=None,
     mets_filename=None,
-    encoding='unicode',
+    encoding=set_encoding,
         structmap_type="DEFAULT"):
     """Builds SIP using JSON for the rep-level information.
 

--- a/tests/data/output_1/content/mets.xml
+++ b/tests/data/output_1/content/mets.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test title</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">true</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">true</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">25678</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_1/pm/presmaster.jpg</key>
-                <key id="fileOriginalName">presmaster.jpg</key>
                 <key id="label">presmaster</key>
+                <key id="fileOriginalName">presmaster.jpg</key>
+                <key id="fileOriginalPath">pm\presmaster.jpg</key>
+                <key id="fileSizeBytes">25678</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,10 +138,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">true</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">MODIFIED_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">true</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -177,12 +177,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">29690</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_1/mm/modifiedmaster.jpg</key>
-                <key id="fileOriginalName">modifiedmaster.jpg</key>
                 <key id="label">modifiedmaster</key>
+                <key id="fileOriginalName">modifiedmaster.jpg</key>
+                <key id="fileOriginalPath">mm\modifiedmaster.jpg</key>
+                <key id="fileSizeBytes">29690</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -218,13 +218,13 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1" USE="VIEW">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp USE="VIEW" ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="pm/presmaster.jpg"/>
       </mets:file>
     </mets:fileGrp>
-    <mets:fileGrp ADMID="rep2-amd" ID="rep2" USE="VIEW">
-      <mets:file ADMID="fid1-2-amd" ID="fid1-2">
+    <mets:fileGrp USE="VIEW" ID="rep2" ADMID="rep2-amd">
+      <mets:file ID="fid1-2" ADMID="fid1-2-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="mm/modifiedmaster.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_2/content/mets.xml
+++ b/tests/data/output_2/content/mets.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test title</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_3/content/dc.xml
+++ b/tests/data/output_3/content/dc.xml
@@ -1,1 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
 <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title>Māori Test Deposit</dc:title></dc:record>

--- a/tests/data/output_3/content/mets.xml
+++ b/tests/data/output_3/content/mets.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>māori</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">25678</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_3/presmaster.jpg</key>
-                <key id="fileOriginalName">presmaster.jpg</key>
                 <key id="label">presmaster</key>
+                <key id="fileOriginalName">presmaster.jpg</key>
+                <key id="fileOriginalPath">C:\Users\sbourke\Documents\00_Python\clones\slv-sip-factory\rosetta_sip_factory\tests\data\test_batch_3\presmaster.jpg</key>
+                <key id="fileSizeBytes">25678</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -132,8 +132,8 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1" USE="VIEW">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd" USE="VIEW">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="presmaster.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_4/content/test1.xml
+++ b/tests/data/output_4/content/test1.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test title</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">true</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">true</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">25678</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_4/img_1.jpg</key>
-                <key id="fileOriginalName">img_1.jpg</key>
                 <key id="label">img_1</key>
+                <key id="fileOriginalName">img_1.jpg</key>
+                <key id="fileOriginalPath">img_1.jpg</key>
+                <key id="fileSizeBytes">25678</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">113715</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_4/img_2.jpg</key>
-                <key id="fileOriginalName">img_2.jpg</key>
                 <key id="label">img_2</key>
+                <key id="fileOriginalName">img_2.jpg</key>
+                <key id="fileOriginalPath">img_2.jpg</key>
+                <key id="fileSizeBytes">113715</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -179,11 +179,11 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1" USE="VIEW">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp USE="VIEW" ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="test1/img_1.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="test1/img_2.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_4/content/test2.xml
+++ b/tests/data/output_4/content/test2.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>Other test title</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">true</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">true</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">25678</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_4/img_1.jpg</key>
-                <key id="fileOriginalName">img_1.jpg</key>
                 <key id="label">img_1</key>
+                <key id="fileOriginalName">img_1.jpg</key>
+                <key id="fileOriginalPath">img_1.jpg</key>
+                <key id="fileSizeBytes">25678</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">2018-03-26T04:31:37</key>
-                <key id="fileCreationDate">2018-03-26T04:31:37</key>
-                <key id="fileSizeBytes">113715</key>
-                <key id="fileOriginalPath">/home/sean/Documents/programming_stuff/python/environments/quickenv/the_ros_env/rosetta_sip_factory/tests/data/test_batch_4/img_2.jpg</key>
-                <key id="fileOriginalName">img_2.jpg</key>
                 <key id="label">img_2</key>
+                <key id="fileOriginalName">img_2.jpg</key>
+                <key id="fileOriginalPath">img_2.jpg</key>
+                <key id="fileSizeBytes">113715</key>
+                <key id="fileCreationDate">2024-04-26T15:28:54</key>
+                <key id="fileModificationDate">2024-04-26T15:28:54</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -179,11 +179,11 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1" USE="VIEW">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp USE="VIEW" ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="test2/img_1.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="test2/img_2.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_0.xml
+++ b/tests/data/output_5/content/test_title_0.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_0</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_1.xml
+++ b/tests/data/output_5/content/test_title_1.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_1</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_2.xml
+++ b/tests/data/output_5/content/test_title_2.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_2</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_3.xml
+++ b/tests/data/output_5/content/test_title_3.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_3</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_4.xml
+++ b/tests/data/output_5/content/test_title_4.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_4</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_5.xml
+++ b/tests/data/output_5/content/test_title_5.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_5</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_6.xml
+++ b/tests/data/output_5/content/test_title_6.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_6</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_7.xml
+++ b/tests/data/output_5/content/test_title_7.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_7</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_8.xml
+++ b/tests/data/output_5/content/test_title_8.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_8</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/data/output_5/content/test_title_9.xml
+++ b/tests/data/output_5/content/test_title_9.xml
@@ -2,7 +2,7 @@
   <mets:dmdSec ID="ie-dmd">
     <mets:mdWrap MDTYPE="DC">
       <mets:xmlData>
-        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <dc:record xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rosetta="http://www.exlibrisgroup.com/dps">
           <dc:title>test_title_9</dc:title>
         </dc:record>
       </mets:xmlData>
@@ -15,8 +15,8 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalIECharacteristics">
               <record>
-                <key id="IEEntityType">periodicIE</key>
                 <key id="submissionReason">bornDigitalContent</key>
+                <key id="IEEntityType">periodicIE</key>
               </record>
             </section>
           </dnx>
@@ -52,10 +52,10 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalRepCharacteristics">
               <record>
-                <key id="RevisionNumber">1</key>
-                <key id="DigitalOriginal">false</key>
-                <key id="usageType">VIEW</key>
                 <key id="preservationType">PRESERVATION_MASTER</key>
+                <key id="usageType">VIEW</key>
+                <key id="DigitalOriginal">false</key>
+                <key id="RevisionNumber">1</key>
               </record>
             </section>
           </dnx>
@@ -91,12 +91,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
-                <key id="note">This is a note for image 1</key>
                 <key id="label">Image One</key>
+                <key id="note">This is a note for image 1</key>
+                <key id="fileOriginalName">freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -138,12 +138,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
-                <key id="fileOriginalName">Experience.jpg</key>
-                <key id="note">This is a note for image 2</key>
                 <key id="label">Image Two</key>
+                <key id="note">This is a note for image 2</key>
+                <key id="fileOriginalName">Experience.jpg</key>
+                <key id="fileOriginalPath">root_folder/tier_2_folder/Experience.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -185,12 +185,12 @@
           <dnx xmlns="http://www.exlibrisgroup.com/dps/dnx">
             <section id="generalFileCharacteristics">
               <record>
-                <key id="fileModificationDate">1st of January, 1601</key>
-                <key id="fileCreationDate">1st of January, 1601</key>
-                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
-                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
-                <key id="note">This is a note for image 3</key>
                 <key id="label">Image Three</key>
+                <key id="note">This is a note for image 3</key>
+                <key id="fileOriginalName">Stock-White-angle-Front.jpg</key>
+                <key id="fileOriginalPath">root_folder/Stock-White-angle-Front.jpg</key>
+                <key id="fileCreationDate">1st of January, 1601</key>
+                <key id="fileModificationDate">1st of January, 1601</key>
               </record>
             </section>
             <section id="fileFixity">
@@ -226,14 +226,14 @@
     </mets:digiprovMD>
   </mets:amdSec>
   <mets:fileSec>
-    <mets:fileGrp ADMID="rep1-amd" ID="rep1">
-      <mets:file ADMID="fid1-1-amd" ID="fid1-1">
+    <mets:fileGrp ID="rep1" ADMID="rep1-amd">
+      <mets:file ID="fid1-1" ADMID="fid1-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid2-1-amd" ID="fid2-1">
+      <mets:file ID="fid2-1" ADMID="fid2-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/tier_2_folder/Experience.jpg"/>
       </mets:file>
-      <mets:file ADMID="fid3-1-amd" ID="fid3-1">
+      <mets:file ID="fid3-1" ADMID="fid3-1-amd">
         <mets:FLocat xmlns:xlin="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlin:href="root_folder/Stock-White-angle-Front.jpg"/>
       </mets:file>
     </mets:fileGrp>

--- a/tests/sip_factory_test.py
+++ b/tests/sip_factory_test.py
@@ -462,7 +462,13 @@ def test_sip_build_multiple_ies():
 
 def test_sip_build_multiple_ies_with_same_named_files():
     """Test to see how this process handles two IEs that both have the same named
-    files."""
+    files.
+    
+    SLV note: This process is not working as expected. The test expects that the files
+    will go directly into content/streams/ however, the process is creating subfolders
+    for each test so the path to the files is content/streams/test1 content/streams/test2.
+    
+    Uncertain what the desired behaviour is for our use case so leaving be for now."""
     output_dir = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 'data',

--- a/tests/sip_factory_test.py
+++ b/tests/sip_factory_test.py
@@ -1,8 +1,9 @@
 import os
 import shutil
+import pathlib
 
 from lxml import etree as ET
-from nose.tools import *
+from pytest import *
 
 from rosetta_sip_factory import sip_builder as sb
 
@@ -243,26 +244,25 @@ def test_sip_single_rep_flat_files():
 
 def test_sip_single_rep_json():
     """Build SIP with single representation with JSON input"""
-
-    pm_json = """[
-        {"fileOriginalName": "img_1.jpg",
+    print(os.path.join(CURRENT_DIR, "data", "test_batch_4"))
+    pm_json = f"""[
+        {{"fileOriginalName": "img_1.jpg",
          "fileOriginalPath": "img_1.jpg",
-         "physical_path" : "%s/img_1.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_4", "img_1.jpg")).as_posix()}",
          "MD5": "9d09f20ab8e37e5d32cdd1508b49f0a9",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image One",
-         "note": "This is a note for image 1"},
-         {"fileOriginalName": "img_2.jpg",
+         "note": "This is a note for image 1"}},
+         {{"fileOriginalName": "img_2.jpg",
          "fileOriginalPath": "img_2.jpg",
-         "physical_path" : "%s/img_2.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_4","img_2.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Two",
-         "note": "This is a note for image 2"}
-    ]""" % (os.path.join(CURRENT_DIR, "data", "test_batch_4"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_4"))
+         "note": "This is a note for image 2"}}
+    ]"""
     # pm_json = """[
     #     {"name": "img_1.jpg",
     #      "path": "%s/img1.jpg",
@@ -460,7 +460,6 @@ def test_sip_build_multiple_ies():
     for f in ['test1.xml', 'test2.xml']:
         assert(f in output_metses)
 
-@raises(Exception)
 def test_sip_build_multiple_ies_with_same_named_files():
     """Test to see how this process handles two IEs that both have the same named
     files."""
@@ -695,36 +694,33 @@ def test_multi_folder_physical_sm_type():
 def test_multi_hierarchical_json_default_structmap():
     """multi-hierarchical json SIPs get a logical SM by default"""
 
-    pm_json = """[
-        {"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
+    pm_json = f"""[
+        {{"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg",
-         "physical_path" : "%s/freedom_isnt_what_i_thought_it_would_be.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2",
+                         "root_folder", "tier_2_folder", "tier_3_folder","freedom_isnt_what_i_thought_it_would_be.jpg")).as_posix()}",
          "MD5": "9d09f20ab8e37e5d32cdd1508b49f0a9",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image One",
-         "note": "This is a note for image 1"},
-         {"fileOriginalName": "Experience.jpg",
+         "note": "This is a note for image 1"}},
+         {{"fileOriginalName": "Experience.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/Experience.jpg",
-         "physical_path" : "%s/Experience.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder","Experience.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Two",
-         "note": "This is a note for image 2"},
-         {"fileOriginalName": "Stock-White-angle-Front.jpg",
+         "note": "This is a note for image 2"}},
+         {{"fileOriginalName": "Stock-White-angle-Front.jpg",
          "fileOriginalPath": "root_folder/Stock-White-angle-Front.jpg",
-         "physical_path" : "%s/Stock-White-angle-Front.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder","Stock-White-angle-Front.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Three",
-         "note": "This is a note for image 3"}
-    ]""" % (os.path.join(CURRENT_DIR, "data", "test_batch_2",
-                         "root_folder", "tier_2_folder", "tier_3_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
-                         "tier_2_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder"))
+         "note": "This is a note for image 3"}}
+    ]""" 
 
     output_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -760,36 +756,34 @@ def test_multi_hierarchical_json_default_structmap():
 def test_multi_hierarchical_json_physical_structmap():
     """multi-hierarchical json SIPs get a physical SM when flagged"""
 
-    pm_json = """[
-        {"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
+    pm_json = f"""[
+        {{"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg",
-         "physical_path" : "%s/freedom_isnt_what_i_thought_it_would_be.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2",
+                         "root_folder", "tier_2_folder", "tier_3_folder","freedom_isnt_what_i_thought_it_would_be.jpg")).as_posix()}",
          "MD5": "9d09f20ab8e37e5d32cdd1508b49f0a9",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image One",
-         "note": "This is a note for image 1"},
-         {"fileOriginalName": "Experience.jpg",
+         "note": "This is a note for image 1"}},
+         {{"fileOriginalName": "Experience.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/Experience.jpg",
-         "physical_path" : "%s/Experience.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
+                         "tier_2_folder","Experience.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Two",
-         "note": "This is a note for image 2"},
-         {"fileOriginalName": "Stock-White-angle-Front.jpg",
+         "note": "This is a note for image 2"}},
+         {{"fileOriginalName": "Stock-White-angle-Front.jpg",
          "fileOriginalPath": "root_folder/Stock-White-angle-Front.jpg",
-         "physical_path" : "%s/Stock-White-angle-Front.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder","Stock-White-angle-Front.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Three",
-         "note": "This is a note for image 3"}
-    ]""" % (os.path.join(CURRENT_DIR, "data", "test_batch_2",
-                         "root_folder", "tier_2_folder", "tier_3_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
-                         "tier_2_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder"))
+         "note": "This is a note for image 3"}}
+    ]"""
 
     output_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -835,36 +829,34 @@ def test_multi_hierarchical_json_physical_structmap():
 def test_multi_hierarchical_json_both_structmaps():
     """multi-hierarchical json SIPs get a physical and logical SM when 'both' is flagged"""
 
-    pm_json = """[
-        {"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
+    pm_json = f"""[
+        {{"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg",
-         "physical_path" : "%s/freedom_isnt_what_i_thought_it_would_be.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2",
+                         "root_folder", "tier_2_folder", "tier_3_folder","freedom_isnt_what_i_thought_it_would_be.jpg")).as_posix()}",
          "MD5": "9d09f20ab8e37e5d32cdd1508b49f0a9",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image One",
-         "note": "This is a note for image 1"},
-         {"fileOriginalName": "Experience.jpg",
+         "note": "This is a note for image 1"}},
+         {{"fileOriginalName": "Experience.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/Experience.jpg",
-         "physical_path" : "%s/Experience.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
+                         "tier_2_folder","Experience.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Two",
-         "note": "This is a note for image 2"},
-         {"fileOriginalName": "Stock-White-angle-Front.jpg",
+         "note": "This is a note for image 2"}},
+         {{"fileOriginalName": "Stock-White-angle-Front.jpg",
          "fileOriginalPath": "root_folder/Stock-White-angle-Front.jpg",
-         "physical_path" : "%s/Stock-White-angle-Front.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder","Stock-White-angle-Front.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Three",
-         "note": "This is a note for image 3"}
-    ]""" % (os.path.join(CURRENT_DIR, "data", "test_batch_2",
-                         "root_folder", "tier_2_folder", "tier_3_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
-                         "tier_2_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder"))
+         "note": "This is a note for image 3"}}
+    ]"""
 
     output_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -965,36 +957,34 @@ def test_multiple_full_IEs_in_one_SIP_folder():
 
 
 def test_multiple_JSON_IEs_in_one_SIP_folder():
-    pm_json = """[
-        {"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
+    pm_json = f"""[
+        {{"fileOriginalName": "freedom_isnt_what_i_thought_it_would_be.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/tier_3_folder/freedom_isnt_what_i_thought_it_would_be.jpg",
-         "physical_path" : "%s/freedom_isnt_what_i_thought_it_would_be.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2",
+                         "root_folder", "tier_2_folder", "tier_3_folder","freedom_isnt_what_i_thought_it_would_be.jpg")).as_posix()}",
          "MD5": "9d09f20ab8e37e5d32cdd1508b49f0a9",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image One",
-         "note": "This is a note for image 1"},
-         {"fileOriginalName": "Experience.jpg",
+         "note": "This is a note for image 1"}},
+         {{"fileOriginalName": "Experience.jpg",
          "fileOriginalPath": "root_folder/tier_2_folder/Experience.jpg",
-         "physical_path" : "%s/Experience.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
+                         "tier_2_folder","Experience.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Two",
-         "note": "This is a note for image 2"},
-         {"fileOriginalName": "Stock-White-angle-Front.jpg",
+         "note": "This is a note for image 2"}},
+         {{"fileOriginalName": "Stock-White-angle-Front.jpg",
          "fileOriginalPath": "root_folder/Stock-White-angle-Front.jpg",
-         "physical_path" : "%s/Stock-White-angle-Front.jpg",
+         "physical_path" : "{pathlib.PureWindowsPath(os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder","Stock-White-angle-Front.jpg")).as_posix()}",
          "MD5": "11c2563db299225b38d5df6287ccda7d",
          "fileCreationDate": "1st of January, 1601",
          "fileModificationDate": "1st of January, 1601",
          "label": "Image Three",
-         "note": "This is a note for image 3"}
-    ]""" % (os.path.join(CURRENT_DIR, "data", "test_batch_2",
-                         "root_folder", "tier_2_folder", "tier_3_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder",
-                         "tier_2_folder"),
-            os.path.join(CURRENT_DIR, "data", "test_batch_2", "root_folder"))
+         "note": "This is a note for image 3"}}
+    ]"""
 
     output_dir = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
Hi, I noticed that when dealing with Unicode characters in filenames, they were not writing to the METS file.

Based on the lxml guidance on [Serialising to Unicode Strings](https://lxml.de/2.0/parsing.html#serialising-to-unicode-strings) I've specified byte encoding 'utf-8' by adding a set_encoding variable.